### PR TITLE
adding describe repo to develop deploy

### DIFF
--- a/.github/workflows/integration-deploy-develop.yml
+++ b/.github/workflows/integration-deploy-develop.yml
@@ -49,7 +49,9 @@ jobs:
             -t $PROJECT_NAME:$IMAGE_TAG \
             -t $PROJECT_NAME:latest \
             -f Dockerfile_ci .
-              
+
+          aws ecr describe-repositories --repository-names $PROJECT_NAME || aws ecr create-repository --repository-name $PROJECT_NAME
+
           aws ecr get-login-password --region sa-east-1 | docker login --username AWS --password-stdin ${{secrets.CR_INTEGRATIONS}}
           
           docker image tag $PROJECT_NAME:latest $IMAGE_NAME:latest


### PR DESCRIPTION
# Pull Request

## Description

* Added `aws ecr` describe-repositories for develop deploy stage 

## Evidences

If the name is correct, it should output something like this:
```
aws ecr describe-repositories --repository-names integration.zili
{
    "repositories": [
        {
            "repositoryUri": "960529452309.dkr.ecr.sa-east-1.amazonaws.com/integration.zili",
            "repositoryName": "integration.zili",
            "registryId": "960529452309",
            "createdAt": 1708956951.321,
            "repositoryArn": "arn:aws:ecr:sa-east-1:960529452309:repository/integration.zili"
        }
    ]
}
```

If it is incorrect, it should output this:
```
aws ecr describe-repositories --repository-names integration.zil || aws ecr create-repository --repository-name integration.zil

An error occurred (RepositoryNotFoundException) when calling the DescribeRepositories operation: The repository with name 'integration.zil' does not exist in the registry with id '960529452309'
{
    "repository": {
        "repositoryName": "integration.zil",
        "repositoryArn": "arn:aws:ecr:sa-east-1:960529452309:repository/integration.zil",
        "createdAt": 1708959528.118,
        "registryId": "960529452309",
        "repositoryUri": "960529452309.dkr.ecr.sa-east-1.amazonaws.com/integration.zil"
    }
}
```

Creating the repository using the project name:
![image](https://github.com/finanzero/fnz-github-workflows/assets/87672055/ab7f04ea-2b71-4ccd-b0f1-f29f32f8cf89)

